### PR TITLE
updated manifest file option

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,9 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.6</version>
                 <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
+                     <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Default useDefaultManifestFile is no longer supported by maven. As per https://stackoverflow.com/questions/38359759/missing-manifest-tag-openide-module, this update emulates what useDefaultManifestFile used to do.